### PR TITLE
feat(playground): usability improvements

### DIFF
--- a/basaran/static/playground.css
+++ b/basaran/static/playground.css
@@ -40,13 +40,19 @@ body {
 .pg-prompt {
     -moz-user-modify: read-write-plaintext-only;
     -webkit-user-modify: read-write-plaintext-only;
+    background-color: transparent;
+    border: 0;
+    box-sizing: border-box;
     font-size: 16px;
+    font-family: inherit;
     line-height: 24px;
     min-height: 72px;
     outline: 0 solid transparent;
     overflow-wrap: anywhere;
     padding: 16px;
+    resize: vertical;
     white-space: pre-wrap;
+    width: 100%;
     word-wrap: anywhere;
 }
 
@@ -132,13 +138,13 @@ body {
     margin-bottom: 8px;
 }
 
-.pg-completion[data-finish=none]::after {
+.pg-completion[data-finish="none"]::after {
     animation: blink 0.8s infinite;
     color: rgb(70, 120, 220);
     content: "|";
 }
 
-.pg-completion[data-finish=length]::after {
+.pg-completion[data-finish="length"]::after {
     background-color: rgb(255, 100, 100);
     border-radius: 4px;
     color: white;
@@ -166,7 +172,7 @@ body {
     width: 250px;
 }
 
-@media(max-width: 600px) {
+@media (max-width: 600px) {
     .pg-right {
         display: none;
     }

--- a/basaran/static/playground.css
+++ b/basaran/static/playground.css
@@ -38,8 +38,6 @@ body {
 }
 
 .pg-prompt {
-    -moz-user-modify: read-write-plaintext-only;
-    -webkit-user-modify: read-write-plaintext-only;
     background-color: transparent;
     border: 0;
     box-sizing: border-box;

--- a/basaran/static/playground.css
+++ b/basaran/static/playground.css
@@ -48,7 +48,7 @@ body {
     outline: 0 solid transparent;
     overflow-wrap: anywhere;
     padding: 16px;
-    resize: vertical;
+    resize: none;
     white-space: pre-wrap;
     width: 100%;
     word-wrap: anywhere;

--- a/basaran/static/playground.js
+++ b/basaran/static/playground.js
@@ -421,7 +421,7 @@ class Inspector {
             inspector.clear();
         }
         completion = new Completion(
-            prompt.innerText,
+            prompt.value,
             handles.options,
             inspector,
             outputs
@@ -434,8 +434,14 @@ class Inspector {
         }
     });
 
+    let resizePrompt = () => {
+        prompt.style.height = 0;
+        prompt.style.height = prompt.scrollHeight + "px";
+    };
+
     document.querySelector(".pg-clear-prompt").addEventListener("click", () => {
-        prompt.textContent = "";
+        prompt.value = "";
+        resizePrompt();
     });
 
     document
@@ -446,4 +452,7 @@ class Inspector {
                 inspector.clear();
             }
         });
+
+    prompt.addEventListener("input", resizePrompt);
+    resizePrompt();
 })();

--- a/basaran/static/playground.js
+++ b/basaran/static/playground.js
@@ -125,7 +125,7 @@ class BooleanHandle {
         input.checked = field.defaultValue;
 
         input.addEventListener("input", () => {
-            field.onSet(input.value);
+            field.onSet(input.checked);
         });
 
         this.field = field;
@@ -133,7 +133,7 @@ class BooleanHandle {
     }
 
     set(value) {
-        this.input.value = value;
+        this.input.checked = value;
     }
 
     get value() {

--- a/basaran/static/presets.json
+++ b/basaran/static/presets.json
@@ -2,12 +2,12 @@
     {
         "id": "default",
         "name": "Default",
-        "temperature": 0.7,
-        "top_k": 40,
+        "temperature": 0,
+        "top_k": 50,
         "top_p": 1,
         "typical_p": 1,
         "penalty_alpha": 0,
-        "repetition_penalty": 1.17
+        "repetition_penalty": 1
     },
     {
         "id": "nai_best_guess",

--- a/basaran/static/presets.json
+++ b/basaran/static/presets.json
@@ -1,0 +1,122 @@
+[
+    {
+        "id": "default",
+        "name": "Default",
+        "temperature": 0.7,
+        "top_k": 40,
+        "top_p": 1,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.17
+    },
+    {
+        "id": "nai_best_guess",
+        "name": "NovelAI - Best Guess",
+        "temperature": 0.8,
+        "top_k": 100,
+        "top_p": 0.9,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.15
+    },
+    {
+        "id": "nai_decadence",
+        "name": "NovelAI - Decadence",
+        "temperature": 2,
+        "top_k": 100,
+        "top_p": 1,
+        "typical_p": 0.97,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1
+    },
+    {
+        "id": "nai_genesis",
+        "name": "NovelAI - Genesis",
+        "temperature": 0.63,
+        "top_k": 100,
+        "top_p": 0.98,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.05
+    },
+    {
+        "id": "nai_lycaenidae",
+        "name": "NovelAI - Lycaenidae",
+        "temperature": 2,
+        "top_k": 12,
+        "top_p": 0.85,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.05
+    },
+    {
+        "id": "nai_ouroboros",
+        "name": "NovelAI - Ouroboros",
+        "temperature": 1.07,
+        "top_k": 100,
+        "top_p": 1,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.05
+    },
+    {
+        "id": "nai_pleasing_results",
+        "name": "NovelAI - Pleasing Results",
+        "temperature": 0.44,
+        "top_k": 100,
+        "top_p": 1,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.15
+    },
+    {
+        "id": "nai_sphinx_moth",
+        "name": "NovelAI - Sphinx Moth",
+        "temperature": 2,
+        "top_k": 30,
+        "top_p": 0.18,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.15
+    },
+    {
+        "id": "nai_storywriter",
+        "name": "NovelAI - Storywriter",
+        "temperature": 0.72,
+        "top_k": 50,
+        "top_p": 0.73,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.1
+    },
+    {
+        "id": "pygmalion",
+        "name": "Pygmalion",
+        "temperature": 0.5,
+        "top_k": 100,
+        "top_p": 0.9,
+        "typical_p": 1,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.1
+    },
+    {
+        "id": "kobold_godlike",
+        "name": "Kobold - Godlike",
+        "temperature": 0.7,
+        "top_k": 100,
+        "top_p": 0.5,
+        "typical_p": 0.19,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.1
+    },
+    {
+        "id": "kobold_liminal_drift",
+        "name": "Kobold - Liminal Drift",
+        "temperature": 0.66,
+        "top_k": 100,
+        "top_p": 1,
+        "typical_p": 0.6,
+        "penalty_alpha": 0,
+        "repetition_penalty": 1.1
+    }
+]

--- a/basaran/templates/playground.html
+++ b/basaran/templates/playground.html
@@ -20,6 +20,7 @@
                 </div>
                 <div class="pg-actions">
                     <button class="pg-button pg-submit">Submit</button>
+                    <button class="pg-button pg-stop">Stop</button>
                     <button class="pg-button pg-clear-prompt">Clear prompt</button>
                     <button class="pg-button pg-clear-completions">Clear completions</button>
                 </div>

--- a/basaran/templates/playground.html
+++ b/basaran/templates/playground.html
@@ -20,7 +20,6 @@
                 </div>
                 <div class="pg-actions">
                     <button class="pg-button pg-submit">Submit</button>
-                    <button class="pg-button pg-stop">Stop</button>
                     <button class="pg-button pg-clear-prompt">Clear prompt</button>
                     <button class="pg-button pg-clear-completions">Clear completions</button>
                 </div>

--- a/basaran/templates/playground.html
+++ b/basaran/templates/playground.html
@@ -16,7 +16,7 @@
         <div class="pg-body">
             <div class="pg-left">
                 <div class="pg-inputs">
-                    <div class="pg-prompt" role="textbox" placeholder="Enter prompt here" contenteditable></div>
+                    <textarea class="pg-prompt" placeholder="Enter prompt here"></textarea>
                 </div>
                 <div class="pg-actions">
                     <button class="pg-button pg-submit">Submit</button>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ bitsandbytes~=0.37.0
 coverage==6.4.2
 flake8==3.7.9
 flask==2.2.1
-huggingface-hub~=0.13.1
+huggingface-hub~=0.12.1
 pytest==6.2.5
 tenacity~=8.2.2
 torch<=1.13.1


### PR DESCRIPTION
I've made some changes to the playground that I think are a big improvement for usability:

- **A stop button:** Sometimes the model produces incoherent completions only after a while, or sometimes you can just tell that the output isn't going where you wanted to. In both cases there's no point in keeping the generation running, but the user might want to keep the results they got so far.
- **Error handling:** The model I use fits very tightly and will easily run out of memory mid-generation. The playground will discard all completions to show an error message even though the completions until this point are fine. So I changed the behavior to keep them.
- **Presets:** I assume that in the future more parameters will be supported. In fact, I already added support for Top-K, Typical-P and Repetition Penalty in my fork (not on Github yet). Using all of these parameters manually is a huge pain, so I added support for presets from a JSON file.
Further improvements that could be implemented are styling the `<select>` input and storing the parameters in LocalStorage so the user doesn't have to reconfigure them all the time.
- **<textarea> for prompt:** Pasting text into the prompt field applied its formatting as well. I found this irritating because you have no way to edit the formatting. Turning the `<div>` into a `<textarea>` fixes this problem.

Idle:
![Bildschirmfoto am 2023-03-13 um 13 25 58](https://user-images.githubusercontent.com/76151476/224701619-7d246904-0290-4d13-82a6-b5a57eb39531.png)

Cancelled generation since it ran out of memory:
![Bildschirmfoto am 2023-03-13 um 13 31 19](https://user-images.githubusercontent.com/76151476/224702694-a55f5e6e-139a-4408-a997-c342f1a7cdef.png)

(Ignore Penalty Alpha, that was just a failed attempt to add contrastive search)
